### PR TITLE
Add baseline repo hygiene files (.gitignore, SECURITY.md, .editorconfig)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Testing & coverage
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.nox/
+coverage.xml
+*.cover
+
+# IDE / editor
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Node
+node_modules/
+npm-debug.log*
+
+# Logs & secrets
+*.log
+.env.local
+.env.*.local

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+privately rather than opening a public issue.
+
+- **Preferred:** open a [private security advisory](https://github.com/varunk130/ai-ux-skill-library/security/advisories/new) on GitHub.
+- Alternatively, contact the maintainer directly via the email listed on the
+  [maintainer's GitHub profile](https://github.com/varunk130).
+
+Please include:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, or a proof-of-concept if possible.
+- Any suggested mitigations you're aware of.
+
+We aim to acknowledge new reports within 7 days and to provide a substantive
+update on remediation within 30 days.
+
+## Supported Versions
+
+This project follows a rolling-release model. Only the latest commit on the
+default branch receives security fixes.
+
+## Scope
+
+Reports about the skills, prompts, and scripts in this repository are in
+scope. Third-party services or upstream model providers are out of scope and
+should be reported to those vendors directly.


### PR DESCRIPTION
Three small, focused commits:

- **.gitignore** covering Python, Node, virtualenvs, IDE/editor, OS, logs, and secret patterns.
- **SECURITY.md** with a private-disclosure flow via GitHub Security Advisories.
- **.editorconfig** to keep encoding, line endings, and indentation consistent across editors.

No behavioral changes to any skills.