### PR TITLE
docs(readme): reconcile 11 vs 12 skill count across body and catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cp -r ai-ux-skill-library/skills/* ~/.claude/skills/
 
 > **Traditional UX skills don't cover AI.** When your product can hallucinate, act autonomously, and produce different outputs from the same input - you need a new UX design vocabulary. This library provides it.
 
-General UX skills (journey mapping, accessibility, design systems) are well-served by existing resources. This library focuses exclusively on the **delta** - the 11 UX challenges that are unique to AI products and don't exist in traditional software or digital products.
+General UX skills (journey mapping, accessibility, design systems) are well-served by existing resources. This library focuses exclusively on the **delta** — the 12 UX challenges that are unique to AI products and don't exist in traditional software or digital products.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ flowchart TD
 
 ## Skills Catalog
 
+12 skills total — 10 core skills (numbered 1–10) plus 2 bonus skills (output/multimodal and accessibility) that extend coverage to rendering and inclusive design.
+
 | # | Skill | Framework | Phase | What It Solves |
 |---|-------|-----------|-------|---------------|
 | 1 | AI Conversation Architect | `DIALOGUE` | Interaction | Conversational AI interfaces - turn-taking, persona voice, multi-turn context, error recovery |


### PR DESCRIPTION
## Summary

The title and badges said **12 skills / 12 frameworks** and the catalog listed 12 (10 core + 2 bonus), but the "Why This Exists" paragraph still said *"the **11** UX challenges that are unique to AI products"* — a leftover from before the bonus skills were added.

## Changes (2 commits)

1. **Fix "11 UX challenges" → "12"** in the "Why This Exists" paragraph so prose matches the catalog, badges, and title.
2. **Explain the 10 core + 2 bonus structure** above the catalog so the badge total (`Skills-12`) makes sense at a glance.

## Follow-up

The GitHub repo description still says *"The 11-Skill AI UX Design Engine"* — updated separately via `gh repo edit`.